### PR TITLE
Add backend package.json for Express server

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "streetemporioroyal-backend",
+  "version": "1.0.0",
+  "description": "STREET EMPORIO ROYAL Backend Server",
+  "main": "server.js",
+  "scripts": {
+    "start": "node server.js",
+    "dev": "node server.js"
+  },
+  "dependencies": {
+    "express": "^4.18.2"
+  },
+  "engines": {
+    "node": ">=18.0.0"
+  }
+}
+


### PR DESCRIPTION
## Fix: Add missing backend/package.json\n\n**Problem:** Build was failing with added 48 packages, and audited 49 packages in 4s

15 packages are looking for funding
  run `npm fund` for details

found 0 vulnerabilities error 127 because  was missing. Railway's rootDirectory is set to , so it needs a package.json there.\n\n**Solution:** Created  with:\n- Express dependency (required by server.js)\n- Correct start command pointing to server.js\n- Node engine requirement (>=18.0.0)\n\n**Result:** Build should now succeed and the Express server will start correctly on port 3000.